### PR TITLE
Renamed a mappool file

### DIFF
--- a/oacmp1_1v1.cfg
+++ b/oacmp1_1v1.cfg
@@ -1,0 +1,1 @@
+oacmpdm1 oacmpdm2 oacmpdm3 oacmpdm4 oacmpdm5 oacmpdm6 oacmpdm7 oacmpdm8 oacmpdm9

--- a/oacmp1_set_mappols.cfg
+++ b/oacmp1_set_mappols.cfg
@@ -16,4 +16,4 @@
 //
 // These have been tested with OpenArena 0.8.8.
 //
-set g_mappools 0\oacmp1_dm.cfg\1\oacmp1_tourney.cfg\3\oacmp1_tdm.cfg\4\oacmp1_ctf.cfg\5\oacmp1_oneflag.cfg\6\oacmp1_obelisk.cfg\7\oacmp1_harvester.cfg\8\oacmp1_elimination.cfg\9\oacmp1_ctf.cfg\10\oacmp1_lms.cfg\11\oacmp1_dd.cfg\12\oacmp1_dom.cfg\
+set g_mappools 0\oacmp1_dm.cfg\1\oacmp1_1v1.cfg\3\oacmp1_tdm.cfg\4\oacmp1_ctf.cfg\5\oacmp1_oneflag.cfg\6\oacmp1_obelisk.cfg\7\oacmp1_harvester.cfg\8\oacmp1_elimination.cfg\9\oacmp1_ctf.cfg\10\oacmp1_lms.cfg\11\oacmp1_dd.cfg\12\oacmp1_dom.cfg\

--- a/oacmp1_tourney.cfg
+++ b/oacmp1_tourney.cfg
@@ -1,1 +1,0 @@
-oacmpdm1 oacmpdm2 oacmpdm3 oacmpdm4 oacmpdm5 oacmpdm6 oacmpdm7 oacmpdm8 oacmpdm9


### PR DESCRIPTION
Renamed oacmp1_tourney.cfg to oacmp1_1v1.cfg, to make the string to enable gametypes a bit shorter. To leave a bit of room in the CVAR, just in case the user may want to also add a mappool for "pos" mode...
